### PR TITLE
feat(controller): allow to pass query param to use as source of token…

### DIFF
--- a/lib/cognito_rails.rb
+++ b/lib/cognito_rails.rb
@@ -35,6 +35,11 @@ module CognitoRails
       send :include, CognitoRails::Controller
       self._cognito_user_class = user_class
     end
+
+    def cognito_token_from(param: nil)
+      send :include, CognitoRails::Controller
+      self._cognito_read_token_from_param = param
+    end
   end
 end
 

--- a/lib/cognito_rails/controller.rb
+++ b/lib/cognito_rails/controller.rb
@@ -10,6 +10,7 @@ module CognitoRails
 
     included do
       class_attribute :_cognito_user_class
+      class_attribute :_cognito_read_token_from_param
     end
 
     # @return [ActiveRecord::Base,nil]
@@ -26,8 +27,12 @@ module CognitoRails
 
     # @return [String,nil] cognito user id
     def external_cognito_id
+      reads_param = self.class._cognito_read_token_from_param
+
+      token = request.query_parameters[reads_param] if reads_param
+
       # @type [String,nil]
-      token = request.headers['Authorization']&.split(' ')&.last
+      token ||= request.headers['Authorization']&.split(' ')&.last unless token.present?
 
       return unless token
 

--- a/lib/cognito_rails/controller.rb
+++ b/lib/cognito_rails/controller.rb
@@ -27,12 +27,12 @@ module CognitoRails
 
     # @return [String,nil] cognito user id
     def external_cognito_id
-      reads_param = self.class._cognito_read_token_from_param
+      reads_from_param = self.class._cognito_read_token_from_param
 
-      token = request.query_parameters[reads_param] if reads_param
+      token = request.query_parameters[reads_from_param] if reads_from_param
 
       # @type [String,nil]
-      token ||= request.headers['Authorization']&.split(' ')&.last unless token.present?
+      token ||= request.headers['Authorization']&.split(' ')&.last unless reads_from_param
 
       return unless token
 

--- a/spec/cognito_rails/controller_spec.rb
+++ b/spec/cognito_rails/controller_spec.rb
@@ -3,6 +3,51 @@ require 'spec_helper'
 RSpec.describe CognitoRails::Controller, type: :model do
   include CognitoRails::Helpers
 
+  context 'with an updated API controller' do
+    class ReadTokenFromParamsController < ActionController::API
+      cognito_authentication
+      cognito_token_from param: :token_in_param
+
+      def request
+        @request ||= OpenStruct.new(
+          {
+            headers: { 'Authorization' => 'token_in_headers' },
+            query_parameters: {
+              token_in_param: 'token_in_params',
+              do_not_check: 'there is something here but not declared on class'
+            }
+          }
+        )
+      end
+    end
+
+    let(:controller) { ReadTokenFromParamsController.new }
+    let(:param_token) { 'token_in_params' }
+    let(:header_token) { 'header_token' }
+
+    it 'returns no user if the bearer from the param is invalid' do
+      expect(CognitoRails::JWT).not_to receive(:decode).with(header_token)
+      expect(CognitoRails::JWT).to receive(:decode).with(param_token).at_least(:once).and_return([{ 'sub' => '111111111' }])
+      expect(controller.current_user).to eq(nil)
+    end
+
+    it 'returns a user if the token in param is correct' do
+      user = User.create!(email: sample_cognito_email, external_id: '111111111')
+
+      expect(CognitoRails::JWT).not_to(
+        receive(:decode)
+        .with(header_token)
+      )
+      expect(CognitoRails::JWT).to(
+        receive(:decode)
+        .with(param_token)
+        .at_least(:once)
+        .and_return([{ 'sub' => user.external_id }])
+      )
+      expect(controller.current_user).to eq(user)
+    end
+  end
+
   context 'with an API controller' do
     class MyApiController < ActionController::API
       cognito_authentication


### PR DESCRIPTION
## In the original version:

The module gets the token from the 'Authorization' header of the request.
It then uses this token to find and return the associated user.

## Updated version:

* adds `cognito_token_from(param: )` so we can use it on our controller to fetch the token from request params instead of headers


### ATTENTION
- I'm aware of the vulnerabilities this might bring to an application, use with caution.